### PR TITLE
getDiffs: str vs unicode

### DIFF
--- a/Products/zms/ZMSRepositoryManager.py
+++ b/Products/zms/ZMSRepositoryManager.py
@@ -220,28 +220,15 @@ class ZMSRepositoryManager(
         l_data = l.get('data')
         r = remote.get(filename, {})
         r_data = r.get('data')
-        if isinstance(l_data, bytes):
-          try:
-            l['data'] = l_data.decode('utf-8')
-          except: # data is no text, but image etc.
-            pass
-        if isinstance(r_data, bytes):
-          try:
-            r['data'] = r_data.decode('utf-8')
-          except:
-            pass
-        # Normalize Windows CR+LF line break to Unix LF in string objects
-        if isinstance(l.get('data'), (str,unicode)):
-          l['data'] = l['data'].replace('\r\n','\n')
-        if isinstance(r.get('data'), (str,unicode)):
-          r['data'] = r['data'].replace('\r\n','\n')
+        # l['data'] = unicode(standard.pystr2(l_data,'utf-8','ignore'))
+        # r['data'] = unicode(standard.pystr2(r_data,'utf-8','ignore'))
+
+        if isinstance(l['data'],(str,unicode)):
+          l['data'] = l['data'].replace('\r','')
+          r['data'] = r['data'].replace('\r','')
+
         if l.get('data') != r.get('data'):
           data = l_data or r_data
-          if isinstance(data, (str,unicode)):
-            try:
-              data = data.encode('utf-8')
-            except:
-              pass
           mt, enc = standard.guess_content_type(filename.split('/')[-1], data)
           diff.append((filename, mt, l.get('id', r.get('id', '?')), l, r))
       return diff

--- a/Products/zms/_repositoryutil.py
+++ b/Products/zms/_repositoryutil.py
@@ -42,7 +42,8 @@ Get class from py-string.
 ######
 # ZMS4
 def get_class(py):
-	if isinstance(py,bytes):
+	if isinstance(py,(str,bytes)):
+		# transform to unicode-type
 		py = py.decode('utf-8')
 	id = re.findall('class (.*?):', py)[0]
 	try:
@@ -68,15 +69,16 @@ def remoteFiles(self, basepath):
 					# Read python-representation of repository-object
 					standard.writeLog(self,"[remoteFiles]: read %s"%filepath)
 					f = open(filepath,"rb")
-					py = standard.pystr(f.read())
+					# py = standard.pystr(f.read())
+					py = f.read()
 					f.close()
 					# Analyze python-representation of repository-object
 					d = {}
 					try:
-							c = get_class(py)
-							d = c.__dict__
+						c = get_class(py)
+						d = c.__dict__
 					except:
-							d['revision'] = standard.writeError(self,"[traverse]: can't analyze filepath=%s"%filepath)
+						d['revision'] = standard.writeError(self,"[traverse]: can't analyze filepath=%s"%filepath)
 					id = d.get('id',name)
 					rd = {}
 					rd['id'] = id
@@ -88,16 +90,16 @@ def remoteFiles(self, basepath):
 					for file in [x for x in names if x != name and not x.startswith('.')]:
 						artefact = os.path.join(path,file)
 						if os.path.isfile(artefact):
-								standard.writeLog(self,"[remoteFiles]: read artefact %s"%artefact)
-								f = open(artefact,"rb")
-								data = f.read()
-								f.close()
-								rd = {}
-								rd['id'] = id
-								rd['filename'] = artefact[len(base)+1:]
-								rd['data'] = data
-								rd['version'] = self.getLangFmtDate(os.path.getmtime(artefact),'eng')
-								r[rd['filename']] = rd
+							standard.writeLog(self,"[remoteFiles]: read artefact %s"%artefact)
+							f = open(artefact,"rb")
+							data = f.read()
+							f.close()
+							rd = {}
+							rd['id'] = id
+							rd['filename'] = artefact[len(base)+1:]
+							rd['data'] = data
+							rd['version'] = self.getLangFmtDate(os.path.getmtime(artefact),'eng')
+							r[rd['filename']] = rd
 		traverse(basepath,basepath)
 	return r
 
@@ -124,10 +126,10 @@ def readRepository(self, basepath, deep=True):
 					# Analyze python-representation of repository-object
 					d = {}
 					try:
-							c = get_class(py)
-							d = c.__dict__
+						c = get_class(py)
+						d = c.__dict__
 					except:
-							d['revision'] = standard.writeError(self,"[readRepository]: ")
+						d['revision'] = standard.writeError(self,"[readRepository]: ")
 					id = d.get('id',name)
 					r[id] = {}
 					for k in [x for x in d if not x.startswith('__')]:
@@ -147,10 +149,10 @@ def readRepository(self, basepath, deep=True):
 										data = f.read()
 										f.close()
 										try:
-												if isinstance(data, bytes):
-														data = data.decode('utf-8')
+											if isinstance(data, bytes):
+												data = data.decode('utf-8')
 										except:
-												pass
+											pass
 										vv['data'] = data
 										break
 								v.append((py.find('\t\t%s ='%kk), vv))

--- a/Products/zms/import/com.zms.foundation-4.0.0.metaobj.xml
+++ b/Products/zms/import/com.zms.foundation-4.0.0.metaobj.xml
@@ -86,7 +86,7 @@
                   <item key="multilang" type="int">0</item>
                   <item key="name"><![CDATA[Level]]></item>
                   <item key="repetitive" type="int">0</item>
-                  <item key="type"><![CDATA[?]]></item>
+                  <item key="type"><![CDATA[levelnfc]]></item>
                 </dictionary>
               </item>
               <item type="dictionary">
@@ -172,7 +172,7 @@
                   <item key="multilang" type="int">1</item>
                   <item key="name"><![CDATA[DC.Creator]]></item>
                   <item key="repetitive" type="int">0</item>
-                  <item key="type"><![CDATA[?]]></item>
+                  <item key="type"><![CDATA[attr_dc_creator]]></item>
                 </dictionary>
               </item>
               <item type="dictionary">
@@ -496,7 +496,7 @@ if 'permalink_key__' in request and 'permalink_val__' in request:
                   <item key="multilang" type="int">0</item>
                   <item key="name"><![CDATA[Level]]></item>
                   <item key="repetitive" type="int">0</item>
-                  <item key="type"><![CDATA[?]]></item>
+                  <item key="type"><![CDATA[levelnfc]]></item>
                 </dictionary>
               </item>
               <item type="dictionary">
@@ -582,7 +582,7 @@ if 'permalink_key__' in request and 'permalink_val__' in request:
                   <item key="multilang" type="int">1</item>
                   <item key="name"><![CDATA[DC.Creator]]></item>
                   <item key="repetitive" type="int">0</item>
-                  <item key="type"><![CDATA[?]]></item>
+                  <item key="type"><![CDATA[attr_dc_creator]]></item>
                 </dictionary>
               </item>
               <item type="dictionary">
@@ -1362,7 +1362,7 @@ return ''
                   <item key="multilang" type="int">0</item>
                   <item key="name"><![CDATA[Level]]></item>
                   <item key="repetitive" type="int">0</item>
-                  <item key="type"><![CDATA[?]]></item>
+                  <item key="type"><![CDATA[levelnfc]]></item>
                 </dictionary>
               </item>
               <item type="dictionary">
@@ -1448,7 +1448,7 @@ return ''
                   <item key="multilang" type="int">1</item>
                   <item key="name"><![CDATA[DC.Creator]]></item>
                   <item key="repetitive" type="int">0</item>
-                  <item key="type"><![CDATA[?]]></item>
+                  <item key="type"><![CDATA[attr_dc_creator]]></item>
                 </dictionary>
               </item>
               <item type="dictionary">
@@ -3097,7 +3097,7 @@ $(function(){
                   <item key="multilang" type="int">1</item>
                   <item key="name"><![CDATA[DC.Creator]]></item>
                   <item key="repetitive" type="int">0</item>
-                  <item key="type"><![CDATA[?]]></item>
+                  <item key="type"><![CDATA[attr_dc_creator]]></item>
                 </dictionary>
               </item>
               <item type="dictionary">

--- a/Products/zms/import/default.metadict.xml
+++ b/Products/zms/import/default.metadict.xml
@@ -195,6 +195,30 @@
       <item key="default"></item>
       <item key="dst_meta_types" type="list">
         <list>
+          <item><![CDATA[ZMSDocument]]></item>
+          <item><![CDATA[ZMSFolder]]></item>
+          <item><![CDATA[ZMS]]></item>
+        </list>
+      </item>
+      <item key="id"><![CDATA[attr_dc_owner]]></item>
+      <item key="keys" type="list">
+        <list>
+        </list>
+      </item>
+      <item key="mandatory" type="int">0</item>
+      <item key="multilang" type="int">1</item>
+      <item key="name"><![CDATA[DC.Owner]]></item>
+      <item key="repetitive" type="int">0</item>
+      <item key="type"><![CDATA[string]]></item>
+    </dictionary>
+  </item>
+  <item type="dictionary">
+    <dictionary>
+      <item key="acquired" type="int">0</item>
+      <item key="custom"></item>
+      <item key="default"></item>
+      <item key="dst_meta_types" type="list">
+        <list>
         </list>
       </item>
       <item key="id"><![CDATA[attr_logo]]></item>

--- a/Products/zms/zopeutil.py
+++ b/Products/zms/zopeutil.py
@@ -73,12 +73,12 @@ def addObject(container, meta_type, id, title, data, permissions={}):
   Add Zope-object to container.
   """
   if meta_type == 'DTML Document':
-    # Enforce to utf-8 unicode type
-    data = unicode(standard.pystr2(data),'utf-8','replace')
+    # Enforce to utf-8 text
+    data = standard.pystr2(data, encoding='utf-8', errors='replace').encode('utf-8')
     addDTMLDocument( container, id, title, data)
   elif meta_type == 'DTML Method':
-    # Enforce to utf-8 unicode type
-    data = unicode(standard.pystr2(data),'utf-8','replace')
+    # Enforce to utf-8 text
+    data = standard.pystr2(data, encoding='utf-8', errors='replace').encode('utf-8')
     addDTMLMethod( container, id, title, data)
   elif meta_type == 'External Method':
     addExternalMethod( container, id, title, data)
@@ -87,8 +87,8 @@ def addObject(container, meta_type, id, title, data, permissions={}):
   elif meta_type == 'Image':
     addImage( container, id, title, data)
   elif meta_type == 'Page Template':
-    # Enforce to utf-8 unicode type
-    data = unicode(standard.pystr2(data),'utf-8','replace')
+    # Enforce to utf-8 text
+    data = standard.pystr2(data, encoding='utf-8', errors='replace').encode('utf-8')
     addPageTemplate( container, id, title, data)
   elif meta_type == 'Script (Python)':
     addPythonScript( container, id, title, data)

--- a/Products/zms/zopeutil.py
+++ b/Products/zms/zopeutil.py
@@ -74,11 +74,11 @@ def addObject(container, meta_type, id, title, data, permissions={}):
   """
   if meta_type == 'DTML Document':
     # Enforce to utf-8 text
-    data = standard.pystr2(data, encoding='utf-8', errors='replace').encode('utf-8')
+    data = standard.pystr2(data, encoding='utf-8', errors='ignore').encode('utf-8')
     addDTMLDocument( container, id, title, data)
   elif meta_type == 'DTML Method':
     # Enforce to utf-8 text
-    data = standard.pystr2(data, encoding='utf-8', errors='replace').encode('utf-8')
+    data = standard.pystr2(data, encoding='utf-8', errors='ignore').encode('utf-8')
     addDTMLMethod( container, id, title, data)
   elif meta_type == 'External Method':
     addExternalMethod( container, id, title, data)
@@ -88,7 +88,7 @@ def addObject(container, meta_type, id, title, data, permissions={}):
     addImage( container, id, title, data)
   elif meta_type == 'Page Template':
     # Enforce to utf-8 text
-    data = standard.pystr2(data, encoding='utf-8', errors='replace').encode('utf-8')
+    data = standard.pystr2(data, encoding='utf-8', errors='ignore').encode('utf-8')
     addPageTemplate( container, id, title, data)
   elif meta_type == 'Script (Python)':
     addPythonScript( container, id, title, data)


### PR DESCRIPTION
Hi @zmsdev,
the main branch works with py2/zope4 on win, but wrong file encoding can not be corrected by pystr2() on py2/zope2 on linux. This PR tries to fix this, but with this status repomanager cannot import the config files anymore. We should discuss this.
Regards
fh  