### PR TITLE
fix standard.compareDate(): normalize tm_isdst-value in struct_time not to trigger mktime-error 

### DIFF
--- a/Products/zms/standard.py
+++ b/Products/zms/standard.py
@@ -1320,18 +1320,19 @@ def compareDate(t0, t1):
   @returns: A negative number if date t0 is before t1, zero if they are equal, or positive if t0 is after t1.
   @rtype: C{int}
   """
-  # Set DST / Daylight Saving Time to -1 (unknown) to avoid problems with mktime
+  
   if isinstance(t0, time.struct_time):
-    t0_list = list(t0)
-    t0_list[8] = -1
-    t0 = time.struct_time(t0_list)
-  if isinstance(t1, time.struct_time):
-    t1_list = list(t1)
-    t1_list[8] = -1
-    t1 = time.struct_time(t1_list)
+    # Normalize tm_dst-variable (DST: Daylight Saving Time) 
+    # in struct_time not to trigger mktime-error 
+    mt0 = time.mktime(stripDateTime(DateTime(format_datetime_iso(t0))))
+  else:
+    mt0 = time.mktime(stripDateTime(getDateTime(t0)))
 
-  mt0 = time.mktime(stripDateTime(getDateTime(t0)))
-  mt1 = time.mktime(stripDateTime(getDateTime(t1)))
+  if isinstance(t1, time.struct_time):
+    mt1 = time.mktime(stripDateTime(DateTime(format_datetime_iso(t1))))
+  else:
+    mt1 = time.mktime(stripDateTime(getDateTime(t1)))
+
   if mt1 > mt0:
     return +1
   elif mt1 < mt0:

--- a/Products/zms/standard.py
+++ b/Products/zms/standard.py
@@ -1160,7 +1160,7 @@ def format_datetime_iso(t):
     tz = time.timezone
   else:
     tz = 0
-  #  The offset of the local (non-DST) timezone, in seconds west of UTC
+  # The offset of the local (non-DST) timezone, in seconds west of UTC
   # (negative in most of Western Europe, positive in the US, zero in the
   # UK).
   #
@@ -1320,6 +1320,16 @@ def compareDate(t0, t1):
   @returns: A negative number if date t0 is before t1, zero if they are equal, or positive if t0 is after t1.
   @rtype: C{int}
   """
+  # Set DST / Daylight Saving Time to -1 (unknown) to avoid problems with mktime
+  if isinstance(t0, time.struct_time):
+    t0_list = list(t0)
+    t0_list[8] = -1
+    t0 = time.struct_time(t0_list)
+  if isinstance(t1, time.struct_time):
+    t1_list = list(t1)
+    t1_list[8] = -1
+    t1 = time.struct_time(t1_list)
+
   mt0 = time.mktime(stripDateTime(getDateTime(t0)))
   mt1 = time.mktime(stripDateTime(getDateTime(t1)))
   if mt1 > mt0:

--- a/Products/zms/standard.py
+++ b/Products/zms/standard.py
@@ -1253,6 +1253,13 @@ def getDateTime(t):
         t = time.mktime( t)
       if not isinstance(t, time.struct_time):
         t = time.localtime( t)
+      else:
+        if t.tm_isdst == 1:
+          # In struct_time normalize tm_dst-value  
+          # (DST: Daylight Saving Time) to avoid mktime-error
+          t = list(t)
+          t[8] = -1
+          t = time.localtime( time.mktime( t))
     except:
       pass
   return t
@@ -1320,19 +1327,8 @@ def compareDate(t0, t1):
   @returns: A negative number if date t0 is before t1, zero if they are equal, or positive if t0 is after t1.
   @rtype: C{int}
   """
-  
-  if isinstance(t0, time.struct_time):
-    # Normalize tm_dst-variable (DST: Daylight Saving Time) 
-    # in struct_time not to trigger mktime-error 
-    mt0 = time.mktime(stripDateTime(DateTime(format_datetime_iso(t0))))
-  else:
-    mt0 = time.mktime(stripDateTime(getDateTime(t0)))
-
-  if isinstance(t1, time.struct_time):
-    mt1 = time.mktime(stripDateTime(DateTime(format_datetime_iso(t1))))
-  else:
-    mt1 = time.mktime(stripDateTime(getDateTime(t1)))
-
+  mt0 = time.mktime(stripDateTime(getDateTime(t0)))
+  mt1 = time.mktime(stripDateTime(getDateTime(t1)))
   if mt1 > mt0:
     return +1
   elif mt1 < mt0:


### PR DESCRIPTION
The `tm_isdst `value in data-type struct-time may trigger an error if applying time.mktime in case of +1.
Actually these struct-time values may be still found sometimes:

![mktime_tm_dst](https://github.com/user-attachments/assets/4c674201-d072-4203-8981-0d813d1d950b)

In latest ZMS5-content struct-time is the standard:

![image](https://github.com/user-attachments/assets/42e3ae40-f05c-42be-90d6-4c62987eb552)


